### PR TITLE
Support initialization of manually created SlashCommand

### DIFF
--- a/slashparse.go
+++ b/slashparse.go
@@ -65,7 +65,12 @@ func NewSlashCommand(slashDef []byte) (s SlashCommand, err error) {
 		return s, unmarshalErr
 	}
 
-	validationErr := validateSlashDefinition(&s)
+	return InitSlashCommand(s)
+}
+
+//InitSlashCommand initializes the provided slash command
+func InitSlashCommand(s SlashCommand) (SlashCommand, error) {
+	validationErr := validateSlashDefinition(s)
 	if validationErr != nil {
 		return s, validationErr
 	}

--- a/slashparse.go
+++ b/slashparse.go
@@ -70,7 +70,7 @@ func NewSlashCommand(slashDef []byte) (s SlashCommand, err error) {
 
 //InitSlashCommand initializes the provided slash command
 func InitSlashCommand(s SlashCommand) (SlashCommand, error) {
-	validationErr := validateSlashDefinition(s)
+	validationErr := validateSlashDefinition(&s)
 	if validationErr != nil {
 		return s, validationErr
 	}


### PR DESCRIPTION
Adds a new helper `InitSlashCommand` for the `NewSlashCommand` function, so the caller does not need to provide a yaml blob to initialize a command.